### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const part = Make('Part', {
 ```
 
 ```ts
-Modify('Lighting', {
+Modify(Lighting, {
 	Name: 'Not Lighting',
 	Ambient: Color3.fromRGB(255, 0, 0),
 });


### PR DESCRIPTION
The signature of `Modify` is `function Modify<T extendsInstance>(instance: T)`, so passing the string name is not the correct
usage as described in the README.md currently.